### PR TITLE
Add aria-label to size select

### DIFF
--- a/src/EditorToolbar/EditorToolbar.js
+++ b/src/EditorToolbar/EditorToolbar.js
@@ -58,7 +58,10 @@ const EditorToolbar = ({
         />
       </span>
       <span className="ql-formats">
-        <select className="ql-size">
+        <select
+          className="ql-size"
+          aria-label={formatMessage({ id: 'stripes-template-editor.toolbar.size.label' })}
+        >
           <option
             aria-label={formatMessage({ id: 'stripes-template-editor.toolbar.size.small' })}
             value="10px"

--- a/src/EditorToolbar/EditorToolbar.js
+++ b/src/EditorToolbar/EditorToolbar.js
@@ -60,7 +60,7 @@ const EditorToolbar = ({
       <span className="ql-formats">
         <select
           className="ql-size"
-          aria-label={formatMessage({ id: 'stripes-template-editor.toolbar.size.label' })}
+          aria-label={formatMessage({ id: 'stripes-template-editor.toolbar.size' })}
         >
           <option
             aria-label={formatMessage({ id: 'stripes-template-editor.toolbar.size.small' })}

--- a/translations/stripes-template-editor/en.json
+++ b/translations/stripes-template-editor/en.json
@@ -11,6 +11,7 @@
   "toolbar.list.bullet": "bullet list",
   "toolbar.indent.decrease": "decrease indent",
   "toolbar.indent.increase": "increase indent",
+  "toolbar.size.label": "size",
   "toolbar.size.small": "small",
   "toolbar.size.normal": "normal",
   "toolbar.size.large": "large",

--- a/translations/stripes-template-editor/en.json
+++ b/translations/stripes-template-editor/en.json
@@ -11,7 +11,7 @@
   "toolbar.list.bullet": "bullet list",
   "toolbar.indent.decrease": "decrease indent",
   "toolbar.indent.increase": "increase indent",
-  "toolbar.size.label": "size",
+  "toolbar.size": "size",
   "toolbar.size.small": "small",
   "toolbar.size.normal": "normal",
   "toolbar.size.large": "large",


### PR DESCRIPTION
# Description
In template editor we have `select` without `label`, so `aria-label` should be added not only to `option` elements but to `select` as well. 
# In scope of task
https://issues.folio.org/browse/UICIRC-464
# Screenshot
![image](https://user-images.githubusercontent.com/55694637/90134711-43b67100-dd7a-11ea-8c4d-8c30a462e989.png)
