### PR TITLE
FOLIO-3250 correctly display numbers

### DIFF
--- a/src/template-resolver.js
+++ b/src/template-resolver.js
@@ -2,7 +2,7 @@ export default function (templateStr) {
   return (tokensList) => {
     return templateStr.replace(/{{([^{}]*)}}/g, (tag, tokenName) => {
       const tokenValue = tokensList[tokenName];
-      return typeof tokenValue === 'string' || typeof r === 'number' ? tokenValue : '';
+      return typeof tokenValue === 'string' || typeof tokenValue === 'number' ? tokenValue : '';
     });
   };
 }


### PR DESCRIPTION
Way back when template handling was included within ui-circulation, it
was refactored from handling single items to handling collections and
this bug was introduced (folio-org/ui-circulation/pull/413).

Somehow, we didn't notice at the time (where was eslint complaining about
`no-undef`???) and I think we didn't notice here because eslint is not
correctly configured:
```
$ yarn lint
yarn run v1.22.10
$ eslint .
Cannot find module 'babel-eslint'
Error: Cannot find module 'babel-eslint'
```

Refs [FOLIO-3250](https://issues.folio.org/browse/FOLIO-3250)