### PR TITLE
UICIRC-428: aria-label missing for token icon in WYSIWYG editor toolbar

### DIFF
--- a/src/EditorToolbar/EditorToolbar.js
+++ b/src/EditorToolbar/EditorToolbar.js
@@ -117,6 +117,7 @@ const EditorToolbar = ({
         <button
           data-test-teplate-editor-tokens
           type="button"
+          aria-label={formatMessage({ id: 'stripes-template-editor.toolbar.token' })}
           className="ql-token"
         >
           {'{ }'}

--- a/translations/stripes-template-editor/en.json
+++ b/translations/stripes-template-editor/en.json
@@ -20,5 +20,6 @@
   "toolbar.align.center": "center",
   "toolbar.align.right": "right",
   "toolbar.align.justify": "justify",
-  "toolbar.link": "link"
+  "toolbar.link": "link",
+  "toolbar.token": "token"
 }


### PR DESCRIPTION
## Purpose
aria-label missing for token icon in WYSIWYG editor toolbar

## Notes
**There is no changelog file in this repository**

## Refs
https://issues.folio.org/browse/UICIRC-428