### PR TITLE
STRIPES-810: Ordered and bulleted lists are superimposed on the text …

### DIFF
--- a/src/quillCustom.css
+++ b/src/quillCustom.css
@@ -37,3 +37,7 @@
 .ql-picker.ql-size .ql-picker-item[data-value="32px"]::before {
   font-size: var(--font-size-xx-large);
 }
+
+.ql-editor li::before {
+  text-indent: 0;
+}


### PR DESCRIPTION
## Purpose
Ordered and bulleted lists are superimposed on the text when the user increases the indent in the "Body" field

## Approach
**Indent** button adds `text-indent` css property to `li` tag. `Li` tag contains `::before` pseudo element which is used to display `li` tag index number in list. `::before` pseudo element inherits `text-indent` css property value from `li` tag so we have to reset it to **0**.

## Refs
https://issues.folio.org/browse/STRIPES-810