### PR TITLE
UINOTES-134 Unable to use the Tab key to create indented lists

### DIFF
--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -84,6 +84,10 @@ class TemplateEditor extends React.Component {
     };
   }
 
+  /*
+    Indent attributor overrides default one globally for TemplateEditor and Quill doesn't support formatters on instance level.
+    Plus there is no unregister functionality, so componentWillUnmount is used to restore default Quill fromatters
+  */
   componentWillUnmount() {
     QuillBlock.tagName = 'p';
 

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -31,7 +31,7 @@ import css from './TemplateEditor.css';
 const QuillAlignStyle = Quill.import('attributors/style/align');
 const QuillSizeStyle = Quill.import('attributors/style/size');
 const QuillBlock = Quill.import('blots/block');
-const QuillIntendStyle = Quill.import('formats/indent');
+const QuillIndentStyle = Quill.import('formats/indent');
 
 Quill.register(QuillAlignStyle, true);
 Quill.register(QuillSizeStyle, true);
@@ -88,7 +88,7 @@ class TemplateEditor extends React.Component {
     QuillBlock.tagName = 'p';
 
     Quill.register(QuillBlock, true);
-    Quill.register('formats/indent', QuillIntendStyle, true);
+    Quill.register('formats/indent', QuillIndentStyle, true);
   }
 
   onChange = (value) => {

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -28,15 +28,13 @@ import '!style-loader!css-loader!react-quill/dist/quill.snow.css';
 import '!style-loader!css-loader!./quillCustom.css';
 import css from './TemplateEditor.css';
 
-const AlignStyle = Quill.import('attributors/style/align');
-const SizeStyle = Quill.import('attributors/style/size');
-const Block = Quill.import('blots/block');
-Block.tagName = 'DIV';
+const QuillAlignStyle = Quill.import('attributors/style/align');
+const QuillSizeStyle = Quill.import('attributors/style/size');
+const QuillBlock = Quill.import('blots/block');
+const QuillIntendStyle = Quill.import('formats/indent');
 
-Quill.register(IndentStyle, true);
-Quill.register(AlignStyle, true);
-Quill.register(SizeStyle, true);
-Quill.register(Block, true);
+Quill.register(QuillAlignStyle, true);
+Quill.register(QuillSizeStyle, true);
 
 class TemplateEditor extends React.Component {
   static propTypes = {
@@ -60,6 +58,11 @@ class TemplateEditor extends React.Component {
   constructor(props) {
     super(props);
 
+    QuillBlock.tagName = 'div';
+
+    Quill.register(QuillBlock, true);
+    Quill.register('formats/indent', IndentStyle, true);
+
     this.quill = React.createRef();
 
     this.modules = {
@@ -79,6 +82,13 @@ class TemplateEditor extends React.Component {
       showTokensDialog: false,
       cursorPosition: null,
     };
+  }
+
+  componentWillUnmount() {
+    QuillBlock.tagName = 'p';
+
+    Quill.register(QuillBlock, true);
+    Quill.register('formats/indent', QuillIntendStyle, true);
   }
 
   onChange = (value) => {


### PR DESCRIPTION
purpose:
https://issues.folio.org/browse/UINOTES-134

cause:
discussed in slack, but shortly TemplateEditor Indent attributor overrides default one globally

approach:
as Quill doesn't support on instance level and doesn't provide unregister functionality, default attributor can be reverted in componentWillUnmount 