### PR TITLE
STRIPES-827 provide stripes v7 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change history for ui-users
+# Change history for stripes-template-editor
 
 ## 3.1.0 IN PROGRESS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Change history for ui-users
+
+## 3.1.0 IN PROGRESS
+
+* Correctly display numbers. Refs FOLIO-3250.
+* Provide missing `aria-label` attribute to tokens button. Refs UICIRC-428.
+* Correctly format `ol`/`ul` values. Refs STRIPES-810.
+* use tab key to create indented lists. Refs UINOTES-134.
+* Provide `@folio/stripes` `v7` compatibility alongside `v6`. Refs STRIPES-827.
+
+## [3.0.0](https://github.com/folio-org/stripes-template-editor/tree/v3.0.0) (2021-01-26)
+[Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v2.0.0...v3.0.0)
+
+* *BREAKING* `@folio/stripes` `v6` compatibility
+
+## [2.0.0](https://github.com/folio-org/stripes-template-editor/tree/v2.0.0) (2020-10-19)
+[Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v1.0.2...v2.0.0)
+
+* *BREAKING* increment @folio/stripes to v5 (#12)
+
+## [1.0.2](https://github.com/folio-org/stripes-template-editor/tree/v1.0.2) (2020-09-25)
+[Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v1.0.0...v1.0.2)

--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
   "name": "@folio/stripes-template-editor",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Provides an embedding of the Quill template editor",
   "repository": "folio-org/stripes-template-editor",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=10.0.0"
-  },
   "main": "src/index.js",
   "scripts": {
     "start": "stripes serve",
@@ -17,7 +14,8 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.1.0",
-    "babel-eslint": "^10.0.3"
+    "babel-eslint": "^10.0.3",
+    "eslint": "^6.2.1"
   },
   "dependencies": {
     "html-to-react": "^1.3.3",
@@ -25,12 +23,13 @@
     "moment": "^2.25.3",
     "prop-types": "^15.5.10",
     "react-barcode": "^1.3.2",
-    "react-to-print": "^2.3.2",
-    "react-quill": "^1.2.7"
+    "react-quill": "^1.2.7",
+    "react-to-print": "^2.3.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^6.0.0",
-    "react": "*",
+    "@folio/stripes": "^6.0.0 || ^7.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-intl": "^5.7.0"
   }
 }


### PR DESCRIPTION
Indicate compatibility with `@folio/stripes` `v7`. The breaking changes from `v6` (react 17, rxjs 6) are not significant here, thus this is not a breaking change. It's possible to argue that adding the `react-dom` peer-dep and a version to the `react` peer-dep mean this _is_ a breaking change, and you'd probably win that fight. Practically speaking, however, those were always requirements but were just not correctly stated. :shrug:

Additional `package.json` cleanup: 
* Add `eslint` to dev-deps; it was missing.
* Omit `engines.node`; this is not a nodejs module, hence this setting is irrelevant.

Refs [STRIPES-827](https://issues.folio.org/browse/STRIPES-827)