### PR TITLE
STRIPES-832 use alpha-prefixes for HTML id attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-template-editor
 
+## 3.1.1 IN PROGRESS
+
+* Prefix UUIDs used for HTML `id` attributes to guarantee a non-numeric-prefix. Refs STRIPES-832.
+
 ## [3.1.0](https://github.com/folio-org/stripes-template-editor/tree/v3.1.0) (2022-10-25)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.0.0...v3.1.0)
 

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -65,8 +65,8 @@ class TemplateEditor extends React.Component {
     Quill.register('formats/indent', IndentStyle, true);
 
     this.quill = React.createRef();
-    this.quillId = uuidv4();
-    this.quillToolbarId = uuidv4();
+    this.quillId = `rte-${uuidv4()}`;
+    this.quillToolbarId = `rte-toolbar-${uuidv4()}`;
 
     this.modules = {
       toolbar: {


### PR DESCRIPTION
Using a naked UUID as an html `id` attribute will cause problems when trying to retrieve elements using CSS selectors because they can start with 0-9 and a-f but a CSS selector can't start with a number. IOW, even though an HTML `id` is technically allowed to start with and contain any character, in order to play nice with CSS selectors they need to start with a letter. And now these two do.

Fixes the bug introduced by #19.

Refs [STRIPES-832](https://issues.folio.org/browse/STRIPES-832)