### PR TITLE
STRIPES-849 support stripes v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-template-editor
 
+## 3.2.0 IN PROGRESS
+
+* Provide `@folio/stripes` `v8` compatibility. Refs STRIPES-849.
+
 ## [3.1.1](https://github.com/folio-org/stripes-template-editor/tree/v3.1.1) (2022-11-14)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.0.1...v3.1.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-template-editor",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Provides an embedding of the Quill template editor",
   "repository": "folio-org/stripes-template-editor",
   "publishConfig": {
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.1.0",
-    "@folio/stripes": "^7.4.100000143",
+    "@folio/stripes": "^8.0.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.2.1"
   },
@@ -29,7 +29,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^6.0.0 || ^7.0.0",
+    "@folio/stripes": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.7.0"


### PR DESCRIPTION
Provide support for stripes v8, along side v7 and v6 since these components do not rely on the API surfaces that have changed since v7.

Refs [STRIPES-849](https://issues.folio.org/browse/STRIPES-849)