### PR TITLE
STRIPES-856: Should have possible handle disabled state for loop by passed function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-template-editor
 
+## IN PROGRESS
+
+* Should have possible handle disabled state for loop by passed function. Refs STRIPES-856.
+
 ## [3.2.0](https://github.com/folio-org/stripes-template-editor/tree/v3.2.0) (2023-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.1.1...v3.2.0)
 

--- a/src/TokensSection/TokensSection.js
+++ b/src/TokensSection/TokensSection.js
@@ -20,7 +20,7 @@ class TokensSection extends Component {
       enabled: PropTypes.bool,
       label: PropTypes.node,
       tag: PropTypes.string,
-      isDisableLoop: PropTypes.oneOfType([
+      isDisabledLoop: PropTypes.oneOfType([
         PropTypes.func,
         PropTypes.oneOf([null]),
       ]),
@@ -36,7 +36,7 @@ class TokensSection extends Component {
       enabled: false,
       label: null,
       tag: null,
-      isDisableLoop: null,
+      isDisabledLoop: null,
     },
     selectedCategory: '',
     onLoopSelect: noop,
@@ -76,17 +76,17 @@ class TokensSection extends Component {
     onLoopSelect(section, checked);
   };
 
-  isDisableLoop = () => {
+  isDisabledLoop = () => {
     const {
       selectedCategory,
       loopConfig: {
         tag,
-        isDisableLoop,
+        isDisabledLoop,
       }
     } = this.props;
 
-    return isFunction(isDisableLoop)
-      ? isDisableLoop(selectedCategory, tag, this.disableLoop)
+    return isFunction(isDisabledLoop)
+      ? isDisabledLoop(selectedCategory, tag, this.disableLoop)
       : this.disableLoop;
   }
 
@@ -139,7 +139,7 @@ class TokensSection extends Component {
                 labelClass={this.disableLoop ? css.disabledItem : ''}
                 value={tag}
                 label={<strong>{label}</strong>}
-                disabled={this.isDisableLoop()}
+                disabled={this.isDisabledLoop()}
                 onChange={this.onLoopChange}
               />
             </>

--- a/src/TokensSection/TokensSection.js
+++ b/src/TokensSection/TokensSection.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   noop,
   isEmpty,
+  isFunction,
 } from 'lodash';
 
 import { Checkbox } from '@folio/stripes/components';
@@ -19,6 +20,10 @@ class TokensSection extends Component {
       enabled: PropTypes.bool,
       label: PropTypes.node,
       tag: PropTypes.string,
+      isDisableLoop: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.oneOf([null]),
+      ]),
     }),
     onLoopSelect: PropTypes.func,
     onSectionInit: PropTypes.func.isRequired,
@@ -31,6 +36,7 @@ class TokensSection extends Component {
       enabled: false,
       label: null,
       tag: null,
+      isDisableLoop: null,
     },
     selectedCategory: '',
     onLoopSelect: noop,
@@ -69,6 +75,20 @@ class TokensSection extends Component {
 
     onLoopSelect(section, checked);
   };
+
+  isDisableLoop = () => {
+    const {
+      selectedCategory,
+      loopConfig: {
+        tag,
+        isDisableLoop,
+      }
+    } = this.props;
+
+    return isFunction(isDisableLoop)
+      ? isDisableLoop(selectedCategory, tag, this.disableLoop)
+      : this.disableLoop;
+  }
 
   render() {
     const {
@@ -119,7 +139,7 @@ class TokensSection extends Component {
                 labelClass={this.disableLoop ? css.disabledItem : ''}
                 value={tag}
                 label={<strong>{label}</strong>}
-                disabled={this.disableLoop}
+                disabled={this.isDisableLoop()}
                 onChange={this.onLoopChange}
               />
             </>


### PR DESCRIPTION
## Purpose
We add new multiples token "Multiple fee/fine charges" that should be unable only for Category = Automated fee/fine charge.  ([UICIRC-904](https://issues.folio.org/browse/UICIRC-904))
stripes-template-editor should have possible handle disabled state for loop by passed function.

## Refs
https://issues.folio.org/browse/STRIPES-856

## Notes 
Associated with https://github.com/folio-org/ui-circulation/pull/1022