### PR TITLE
STRIPES-896 - upgrade react-quill version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## IN PROGRESS
 
+* upgrade `react-quill` version to `2.0.0`.
+
+## [3.3.0](https://github.com/folio-org/stripes-template-editor/tree/v3.2.0) (2023-10-13)
+[Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.2.0...v3.3.0)
+
 * Should have possible handle disabled state for loop by passed function. Refs STRIPES-856.
 * Bump Node.js to v18 in CI. Refs STRIPES-887.
 * Support React v18. Refs STRIPES-886.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "moment": "^2.25.3",
     "prop-types": "^15.5.10",
     "react-barcode": "^1.3.2",
-    "react-quill": "^1.2.7",
+    "react-quill": "^2.0.0",
     "react-to-print": "^2.3.2",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
[STRIPES-896](https://issues.folio.org/browse/STRIPES-896) - Template editor: Space and enter keys no longer working properly