### PR TITLE
STRIPES-908 add Barcode to allow-list

### DIFF
--- a/src/PreviewModal/PreviewModal.js
+++ b/src/PreviewModal/PreviewModal.js
@@ -104,7 +104,7 @@ class PreviewModal extends React.Component {
     } = this.props;
 
     const tmpl = templateResolver(previewTemplate);
-    const componentStr = DOMPurify.sanitize(tmpl(previewFormat));
+    const componentStr = DOMPurify.sanitize(tmpl(previewFormat), { ADD_TAGS: ['Barcode'] });
 
     const contentComponent = this.parser.parseWithInstructions(componentStr, () => true, this.rules);
 


### PR DESCRIPTION
JSX for `<Barcode>` is handled specifically here, and so needs to be specifically escaped because otherwise the sanitizer will see it as an unknown tag and strip it.

This is a follow-up to #58 where we added sanitization but not escaping, which had the effect of eliminating XSS (yay!) ... but also eliminating barcodes (whoops).

Refs [STRIPES-908](https://folio-org.atlassian.net/issues/STRIPES-908)