### PR TITLE
STRIPES-918: Add a `bound` template option with template ID to fix the overflowing Link tooltip issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * upgrade `react-quill` version to `2.0.0`. Refs STRIPES-896.
 * Push template content through DOMPurify to avoid XSS vulnerabilities. Refs STRIPES-908.
-* Fix overflow issue with React Quill Template Link tooltip. Refs STRIPES-918.
+* Add a `bound` template option with template ID to fix the overflowing Link tooltip issue. Refs STRIPES-918.
 
 ## [3.3.0](https://github.com/folio-org/stripes-template-editor/tree/v3.2.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.2.0...v3.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * upgrade `react-quill` version to `2.0.0`. Refs STRIPES-896.
 * Push template content through DOMPurify to avoid XSS vulnerabilities. Refs STRIPES-908.
+* Fix overflow issue with React Quill Template Link tooltip. Refs STRIPES-918.
 
 ## [3.3.0](https://github.com/folio-org/stripes-template-editor/tree/v3.2.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.2.0...v3.3.0)

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -233,6 +233,7 @@ class TemplateEditor extends React.Component {
                     modules={this.modules}
                     onChange={this.onChange}
                     onBlur={this.onBlur}
+                    bounds={`#${this.quillId}`}
                   />
                 </div>
               </Col>


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/STRIPES-918 -  Add a `bound` template option with template ID to fix the overflowing Link tooltip issue
## Approach: 
Assign TemplateEditor's id as the value of `bound` option. Because according to [the documentation](https://github.com/zenoamaro/react-quill) it is bound to body element.

> bounds : Selector or DOM element used by Quill to constrain position of popups. Defaults to document.body.




## Current result
![Screenshot 2024-05-06 at 20 23 59](https://github.com/folio-org/stripes-template-editor/assets/116072773/b94f23c7-d0db-43eb-967c-2e35bb8e1471)
## Expected result
![Screenshot 2024-05-06 at 20 25 00](https://github.com/folio-org/stripes-template-editor/assets/116072773/36ccdf81-e7db-4d63-ac70-46d45a0b9fb8)
