### PR TITLE
STRIPES-953 Only use DOMPurify's output if it changed something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-template-editor
 
 ## IN PROGRESS
+* Only change `value` prop to `ReactQuill` if `DOMPurify` made changes. Refs STRIPES-953.
 
 ## [3.4.1](https://github.com/folio-org/stripes-template-editor/tree/v3.4.1) (2024-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.4.0...v3.4.1)

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -212,6 +212,17 @@ class TemplateEditor extends React.Component {
 
     const invalid = (touched || submitFailed) && !valid && !showTokensDialog;
 
+    // DOMPurify reverses the order of attributes, so any supplied tags with attributes will ALWAYS
+    // have different output - so we just check for any changes DOMPurify might have made before using
+    // the string it produces.
+    let appliedValue = DOMPurify.sanitize(value, { ADD_TAGS: ['Barcode'], ADD_ATTR: ['target', 'rel'] });
+    if (value !== appliedValue) {
+      const removed = DOMPurify.removed.map((item) => item.attribute?.name || item.element?.outerHTML);
+      if (removed && removed.length === 0) {
+        appliedValue = value;
+      }
+    }
+
     return (
       <>
         <Row>
@@ -228,7 +239,7 @@ class TemplateEditor extends React.Component {
                   <ReactQuill
                     id={this.quillId}
                     className={css.editor}
-                    value={DOMPurify.sanitize(value, { ADD_TAGS: ['Barcode'] })}
+                    value={appliedValue}
                     ref={this.quill}
                     modules={this.modules}
                     onChange={this.onChange}


### PR DESCRIPTION
`ReactQuill` has a funny behavior- if the input `value` attribute is different from what it provided to its `onChange` handler, it will reset its cursor state and put it back at the beginning of the string. The HTML for links output by `ReactQuill` are generally not offensive, but reversing the attribute order during the value lifecycle resets the cursor repeatedly, even for non-offending templates...

`DOMPurify` also has a funny behavior, it reverses the attributes of any tag that you feed it.

This PR checks for any changes that `DOMPurify` would make to the string, and if there are none, it just uses the string...
A tempting alternative approach would be to just call `DOMPurify.sanitize` twice 🤢 and be done with it... it may come to that in the future.

I also added `target` and `rel` to `sanitize` settings to prevent unwanted removals from happening.

Refs [STRIPES-953](https://folio-org.atlassian.net/browse/STRIPES-953)