### PR TITLE
STRIPES-965 support react-intl v7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn.lock
 ModuleDescriptor.json
 yarn-error.log
 artifacts
+translations/stripes-template-editor/compiled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change history for stripes-template-editor
 
 ## IN PROGRESS
+
 * Only change `value` prop to `ReactQuill` if `DOMPurify` made changes. Refs STRIPES-953.
 * Export `sanitize` function for module-level value sanitization. Refs STRIPES-953 also.
+* Support `react-intl` `v7`, compile translations. Refs STRIPES-965.
 
 ## [3.4.1](https://github.com/folio-org/stripes-template-editor/tree/v3.4.1) (2024-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.4.0...v3.4.1)

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "main": "src/index.js",
   "scripts": {
     "start": "stripes serve",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^7.0.0",
-    "@folio/stripes": "^9.0.0"
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-cli": "^4.0.0"
   },
   "dependencies": {
     "dompurify": "^3.1.3",
@@ -28,9 +30,9 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "@folio/stripes": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "react": "^17.0.2 || ^18.2.0",
     "react-dom": "^17.0.2 || ^18.2.0",
-    "react-intl": "^5.7.0 || ^6.4.7"
+    "react-intl": "^5.7.0 || ^6.4.7 || ^7.1.5"
   }
 }


### PR DESCRIPTION
Extend `react-intl` support to `v7`, and provide a `formatjs-compile` script to compile translations.

Refs [STRIPES-965](https://folio-org.atlassian.net/browse/STRIPES-965)