### PR TITLE
[STRIPES-974] Raw HTML editing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,4 @@
 {
   "parser": "@babel/eslint-parser",
-  "extends": "@folio/eslint-config-stripes",
-  "rules": {
-    "react/forbid-prop-types": [1, { "forbid": ["any", "array"] }]
-  }
+  "extends": "@folio/eslint-config-stripes"
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "parser": "@babel/eslint-parser",
-  "extends": "@folio/eslint-config-stripes"
+  "extends": "@folio/eslint-config-stripes",
+  "rules": {
+    "react/forbid-prop-types": [1, { "forbid": ["any", "array"] }]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-template-editor
 
+## [3.6.0](https://github.com/folio-org/stripes-template-editor/tree/v3.6.0) (IN PROGRESS)
+[Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.5.0...v3.6.0)
+
+* `<TemplateEditor>` accepts a new optional boolean prop `editAsHtml`, defaulting backwards-compatibly to false. When present and true, the editor is a simple `<TextArea>` with which the advanced user can edit the raw HTML of the template; when absent or false, the old behaviour of the Quill-based editor is used. Fixes STRIPES-974.
+
 ## [3.5.0](https://github.com/folio-org/stripes-template-editor/tree/v3.5.0) (2025-03-13)
 [Full Changelog](https://github.com/folio-org/stripes-template-editor/compare/v3.4.2...v3.5.0)
 

--- a/src/ControlHeader/ControlHeader.js
+++ b/src/ControlHeader/ControlHeader.js
@@ -10,7 +10,7 @@ import {
 
 import css from './ControlHeader.css';
 
-const ControlHeader = ({ label, onPreviewClick, required }) => {
+const ControlHeader = ({ label, onPreviewClick, required, extraButton }) => {
   return (
     <Row bottom="xs">
       <Col xs={9}>
@@ -25,6 +25,7 @@ const ControlHeader = ({ label, onPreviewClick, required }) => {
       <Col xs={3}>
         <Row className={css.preview}>
           <Col>
+            {extraButton}
             <Button
               bottomMargin0
               onClick={onPreviewClick}

--- a/src/ControlHeader/ControlHeader.js
+++ b/src/ControlHeader/ControlHeader.js
@@ -43,6 +43,7 @@ ControlHeader.propTypes = {
   label: PropTypes.node.isRequired,
   required: PropTypes.bool.isRequired,
   onPreviewClick: PropTypes.func.isRequired,
+  extraButton: PropTypes.object,
 };
 
 export default ControlHeader;

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -180,7 +180,7 @@ class TemplateEditor extends React.Component {
       // more verbose and less clear way to satisfy the hungry gods of
       // ESLint. Truly, this is an age of wonders.
       elem.selectionStart = start + text.length;
-      elem.selectionStart = start + text.length;
+      elem.selectionEnd = start + text.length;
     });
   };
 

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -146,7 +146,14 @@ class TemplateEditor extends React.Component {
     }
   };
 
-  // Note: this does not attempt to support `isLoopSelected`, as I can't find a way to exercise that
+  // Note: this does not attempt to support `isLoopSelected`.
+  //
+  // The immediate need for HTML editing is in the context of staff
+  // slips, which do not seem to make use of loops. When we come to
+  // the point of needing HTML editing for other kinds of templates
+  // that use them, that will give us the opportunity (and motivation)
+  // for writing and running the relevant new code.
+  //
   insertTokensIntoHtml = (tokens = {}) => {
     const text = Object.keys(tokens).map(key => tokens[key].tokens.map(s => `{{${s}}}`).join('')).join('');
 

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -152,14 +152,24 @@ class TemplateEditor extends React.Component {
   // functions used to insert tokens into the HTML of the TextArea or
   // into the Quill editor -- the appropriate function is called
   // depending on which kind of editor is in use.
+
+  // Note: the HTML version does not attempt to support
+  // `isLoopSelected`.  The immediate need for HTML editing is in the
+  // context of staff slips, which do not make use of loops. When we
+  // come to the point of needing HTML editing for other kinds of
+  // templates that use them, that will give us the opportunity (and
+  // motivation) for writing and running the relevant new code.
   //
-  // Note: this does not attempt to support `isLoopSelected`.
-  //
-  // The immediate need for HTML editing is in the context of staff
-  // slips, which do not seem to make use of loops. When we come to
-  // the point of needing HTML editing for other kinds of templates
-  // that use them, that will give us the opportunity (and motivation)
-  // for writing and running the relevant new code.
+  // Because the textarea is controlled by react-final-form, we have
+  // to use its API (the `input.onChange` prop) to set the value,
+  // rather than just manipulating the DOM element. But there is no
+  // final-form API for reading the selection start and end, or for
+  // setting the cursor position. (These are considered state rather
+  // than value, and final-form is concerned only with values.)
+  // Consequently the value in the DOM element doesn't get set until
+  // final-form has had a chance to operate: hence the use of
+  // requestAnimationFrame to delay the positioning of the cursor
+  // until that has happened.
   //
   insertTokensIntoHtml = (tokens = {}) => {
     const text = Object.keys(tokens).map(key => tokens[key].tokens.map(s => `{{${s}}}`).join('')).join('');

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -168,7 +168,7 @@ class TemplateEditor extends React.Component {
     const start = elem.selectionStart;
     const end = elem.selectionEnd;
     const newValue = elem.value.substring(0, start) + text + elem.value.substring(end);
-    this.props.input.onChange(newValue);
+    this.props.input.onChange(sanitize(newValue));
 
     requestAnimationFrame(() => {
       elem.focus();
@@ -291,7 +291,7 @@ class TemplateEditor extends React.Component {
                     ref={this.textAreaRef}
                     name={name}
                     value={value}
-                    onChange={this.props.input.onChange}
+                    onChange={newValue => this.props.input.onChange(sanitize(newValue))}
                     rows="12"
                   /> :
                   <div {... invalid ? { className: css.error } : {}}>

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -156,12 +156,11 @@ class TemplateEditor extends React.Component {
     const newValue = elem.value.substring(0, start) + text + elem.value.substring(end);
     this.props.input.onChange(newValue);
 
-    // XXX The rest of this function seems to no-op
-    // Move the cursor to just after the inserted text
-    const newCursorPos = start + text.length;
-    // eslint-disable-next-line no-multi-assign
-    elem.selectionStart = elem.selectionEnd = newCursorPos;
-    elem.focus();
+    requestAnimationFrame(() => {
+      elem.focus();
+      // eslint-disable-next-line no-multi-assign
+      elem.selectionStart = elem.selectionEnd = start + text.length;
+    });
   };
 
   insertTokensIntoQuill = (tokens = {}) => {

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -168,7 +168,7 @@ class TemplateEditor extends React.Component {
     const start = elem.selectionStart;
     const end = elem.selectionEnd;
     const newValue = elem.value.substring(0, start) + text + elem.value.substring(end);
-    this.props.input.onChange(sanitize(newValue));
+    this.props.input.onChange(newValue);
 
     requestAnimationFrame(() => {
       elem.focus();

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { injectIntl } from 'react-intl';
 import ReactQuill, { Quill } from 'react-quill';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -52,6 +53,7 @@ class TemplateEditor extends React.Component {
     required: PropTypes.bool,
     selectedCategory: PropTypes.string,
     editAsHtml: PropTypes.bool,
+    intl: PropTypes.object,
   };
 
   static defaultProps = {
@@ -254,6 +256,7 @@ class TemplateEditor extends React.Component {
       selectedCategory,
       name,
       editAsHtml,
+      intl: { formatMessage }
     } = this.props;
 
     const invalid = (touched || submitFailed) && !valid && !showTokensDialog;
@@ -264,8 +267,9 @@ class TemplateEditor extends React.Component {
       <Button
         bottomMargin0
         onClick={this.openTokenDialog}
+        aria-label={formatMessage({ id: 'stripes-template-editor.toolbar.token' })}
       >
-        {'{}'}
+        {'{ }'}
       </Button>
     );
 
@@ -330,4 +334,4 @@ class TemplateEditor extends React.Component {
   }
 }
 
-export default TemplateEditor;
+export default injectIntl(TemplateEditor);

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -146,6 +146,11 @@ class TemplateEditor extends React.Component {
     }
   };
 
+  // insertTokensIntoHtml() and insertTokensIntoQuill() are equivalent
+  // functions used to insert tokens into the HTML of the TextArea or
+  // into the Quill editor -- the appropriate function is called
+  // depending on which kind of editor is in use.
+  //
   // Note: this does not attempt to support `isLoopSelected`.
   //
   // The immediate need for HTML editing is in the context of staff

--- a/src/TemplateEditor.js
+++ b/src/TemplateEditor.js
@@ -170,8 +170,15 @@ class TemplateEditor extends React.Component {
 
     requestAnimationFrame(() => {
       elem.focus();
-      // eslint-disable-next-line no-multi-assign
-      elem.selectionStart = elem.selectionEnd = start + text.length;
+      // In a rational world, we would just do a multiple assignment
+      // here, but someone somewhere decided that ESLint ought to
+      // whine about that, because of course an automated tool has
+      // better taste than an actual programmer with 45 years'
+      // experience, so instead we will express the intention in a
+      // more verbose and less clear way to satisfy the hungry gods of
+      // ESLint. Truly, this is an age of wonders.
+      elem.selectionStart = start + text.length;
+      elem.selectionStart = start + text.length;
     });
   };
 


### PR DESCRIPTION
`<TemplateEditor>` accepts a new optional boolean prop `editAsHtml`, defaulting backwards-compatibly to false. When present and true, the editor is a simple `<TextArea>` with which the advanced user can edit the raw HTML of the template; when absent or false, the old behaviour of the Quill-based editor is used.

Fixes STRIPES-974.